### PR TITLE
Make Wharton Python Vagrant work with Learning Lab SIMPL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--cpuexecutioncap", "75"]
         v.customize ["modifyvm", :id, "--vram", "12"]
         v.customize ["modifyvm", :id, "--ioapic", "on"]
+        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
     end
 
     # Set up a private IP that can be added to the host machine's hosts file

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,6 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--cpuexecutioncap", "75"]
         v.customize ["modifyvm", :id, "--vram", "12"]
         v.customize ["modifyvm", :id, "--ioapic", "on"]
-        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
     end
 
     # Set up a private IP that can be added to the host machine's hosts file

--- a/provisioning/roles/firewalld/tasks/main.yml
+++ b/provisioning/roles/firewalld/tasks/main.yml
@@ -15,3 +15,15 @@
     port: 8000/tcp
     permanent: true
     state: enabled
+
+# SIMPL Model Service
+- firewalld:
+    port: 8080/tcp
+    permanent: true
+    state: enabled
+
+# SIMPL API
+- firewalld:
+    port: 8100/tcp
+    permanent: true
+    state: enabled

--- a/provisioning/roles/postgresql/tasks/main.yml
+++ b/provisioning/roles/postgresql/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Install Postgresql Team YUM repo
+  yum:
+    name: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm
+    state: present
+
+- name: Install PostgreSQL 9.6 Server
+  yum:
+    name: postgresql96-server
+    state: present
+
+- name: Install PostgreSQL 9.6 devel package
+  yum:
+    name: postgresql96-devel
+    state: present
+
+- name: Install PostgreSQL 9.6 contrib package
+  yum:
+    name: postgresql96-contrib
+    state: present
+
+- name: Initialize PostgreSQL 9.6
+  command: /usr/pgsql-9.6/bin/postgresql96-setup initdb creates=/var/lib/pgsql/9.6/initdb.log
+  become: true
+  become_user: root
+
+- name: Ensure PostgreSQL 9.6 service is running
+  service: name=postgresql-9.6 state=started enabled=yes
+
+- name: Ensure psycopg2 is installed
+  yum:
+    name: python-psycopg2
+    state: present
+
+- name: Create vagrant PostgreSQL database user
+  postgresql_user: name=vagrant role_attr_flags=SUPERUSER state=present
+  become: yes
+  become_user: postgres
+  become_method: sudo

--- a/provisioning/vagrant_playbook.yml
+++ b/provisioning/vagrant_playbook.yml
@@ -15,6 +15,7 @@
     - { role: freetds, tags: ['sql', 'freetds'] }
     - { role: elastic_search, tags: ['search', 'elastic'] }
     - { role: redis, tags: ['cache', 'redis'] }
+    - { role: postgresql, tags: ['postgresql']}
     # The following line will use the Microsoft driver
     # We're using FreeTDS.
     # - { role: mssql, tags: ['sql'] }


### PR DESCRIPTION
Hello! 

For learning lab to use this Vagrant we needed a couple of extra things: 

- PostgreSQL 9.6
- Port 8080 and 8100 open 

These changes, you know, do that.  